### PR TITLE
Catch errors for reflect.Set

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -455,11 +455,11 @@ func (p *hjsonParser) checkTrailing(v interface{}, err error) (interface{}, erro
 // Unmarshal uses the inverse of the encodings that
 // Marshal uses, allocating maps, slices, and pointers as necessary.
 //
-func Unmarshal(data []byte, v interface{}) error {
-
+func Unmarshal(data []byte, v interface{}) (err error) {
+	var value interface{}
 	parser := &hjsonParser{data, 0, ' '}
 	parser.resetAt()
-	value, err := parser.rootValue()
+	value, err = parser.rootValue()
 	if err != nil {
 		return err
 	}
@@ -471,6 +471,11 @@ func Unmarshal(data []byte, v interface{}) error {
 	for rv.Kind() == reflect.Ptr {
 		rv = rv.Elem()
 	}
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("%v", e)
+		}
+	}()
 	rv.Set(reflect.ValueOf(value))
-	return nil
+	return err
 }

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -97,3 +97,11 @@ func TestHjson(t *testing.T) {
 		}
 	}
 }
+
+func TestInvalidDestinationType(t *testing.T) {
+	var dat map[string]interface{}
+	err := Unmarshal([]byte(`[1,2,3,4]`), &dat)
+	if err == nil {
+		panic("An error should occur")
+	}
+}


### PR DESCRIPTION
if `reflect.Set` throws any errors the whole application crashes.  
Instead catch them using `recover`.

I added a Test that should make clear the case.

