### PR TITLE
Add support for comments in structs

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -346,6 +346,7 @@ func (e *hjsonEncoder) str(value reflect.Value, noIndent bool, separator string,
 
 			name := curStructField.Name
 			jsonTag := curStructField.Tag.Get("json")
+			jsonComment := curStructField.Tag.Get("comment")
 			omitEmpty := false
 			if jsonTag == "-" {
 				continue
@@ -364,11 +365,22 @@ func (e *hjsonEncoder) str(value reflect.Value, noIndent bool, separator string,
 			if omitEmpty && isEmptyValue(curField) {
 				continue
 			}
+			if len(jsonComment) > 0 {
+				for _, line := range strings.Split(jsonComment, e.Eol) {
+					e.WriteString(separator)
+					e.writeIndent(e.indent)
+					e.WriteString(fmt.Sprintf("# %s", line))
+					e.WriteString(separator)
+				}
+			}
 			e.writeIndent(e.indent)
 			e.WriteString(e.quoteName(name))
 			e.WriteString(":")
 			if err := e.str(curField, false, " ", false); err != nil {
 				return err
+			}
+			if len(jsonComment) > 0 && i < l-1 {
+				e.WriteString(e.Eol)
 			}
 		}
 


### PR DESCRIPTION
Allows comments to be added to struct definitions and included in the marshalled output. Comments containing `\n` will be split across multiple commented lines. 

As an example:
```
type foo struct {
  a    string    `comment:"First comment"`
  b    int32     `comment:"Second comment\nLook ma, new lines"`
}

func main() {
	a := foo{ a: "hi!", b: 3 }
	h, err := hjson.Marshal(a)
	if err != nil {
		panic(err)
	}
	fmt.Println(string(h))
}
```
... produces the following:
```
{
  # First comment
  a: hi!

  # Second comment
  # Look ma, new lines
  b: 3
}
```