### PR TITLE
Make True/False/Null in decode case insensitive.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -282,15 +282,15 @@ func (p *hjsonParser) readTfnns() (interface{}, error) {
 			p.ch == '/' && (p.peek(0) == '/' || p.peek(0) == '*') {
 			switch chf {
 			case 'f':
-				if strings.TrimSpace(value.String()) == "false" {
+				if strings.EqualFold(strings.TrimSpace(value.String()), "false") {
 					return false, nil
 				}
 			case 'n':
-				if strings.TrimSpace(value.String()) == "null" {
+				if strings.EqualFold(strings.TrimSpace(value.String()), "null") {
 					return nil, nil
 				}
 			case 't':
-				if strings.TrimSpace(value.String()) == "true" {
+				if strings.EqualFold(strings.TrimSpace(value.String()), "true") {
 					return true, nil
 				}
 			default:


### PR DESCRIPTION
This makes the the parser a little less error tolerant from the strict standard.

One example of a .json file that uses non-standard casing is in Chromium: https://chromium.googlesource.com/chromium/src/components/policy/+/master/resources/policy_templates.json