### PR TITLE
add UnmarshalPartially

### DIFF
--- a/hjson_test.go
+++ b/hjson_test.go
@@ -105,3 +105,34 @@ func TestInvalidDestinationType(t *testing.T) {
 		panic("An error should occur")
 	}
 }
+
+func TestUnmarshalPartially(t *testing.T) {
+	var src = `
+	{
+		database:
+		{
+		  host: 127.0.0.1
+		  port: 555
+		}
+	  }
+	@@there is sth cannot be parsed as hijson.
+	`
+	v, next, err := UnmarshalPartially([]byte(src))
+	if err != nil {
+		panic(err)
+	}
+	if next != strings.Index(src, "@") {
+		panic("wrong next value")
+	}
+	if v == nil {
+		panic("v is nil")
+	}
+	val, ok := v.(map[string]interface{})
+	if !ok {
+		panic("v has wrong type")
+	}
+	_, ok = val["database"]
+	if !ok {
+		panic("v has wrong value")
+	}
+}


### PR DESCRIPTION
In our project, we use hjson as part of configs, it's mixed with other format texts.
So we need read the part of hjson by hjson-go and keep the left part to other programs.
I added the function `UnmarshalPartially` to do this work.
`UnmarshalPartially` reads characters from the beginning, add try to parse them as hjson.
It stops when meeting wrong formats or finishing a complete hjson structure. 
It returns the parsed value,  the start position of the unprocessed part and error if has.