### PR TITLE
Fix Unmarshal panicking when called with a nil value

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -2,7 +2,6 @@ package hjson
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -117,7 +116,7 @@ func (p *hjsonParser) readString(allowML bool) (string, error) {
 				return "", p.errAt("Bad escape \\" + string(p.ch))
 			}
 		} else if p.ch == '\n' || p.ch == '\r' {
-			return "", p.errAt("Bad string containing newline");
+			return "", p.errAt("Bad string containing newline")
 		} else {
 			res.WriteByte(p.ch)
 		}
@@ -425,7 +424,7 @@ func (p *hjsonParser) rootValue() (interface{}, error) {
 	}
 
 	// assume we have a root object without braces
-	res, err := p.checkTrailing(p.readObject(true));
+	res, err := p.checkTrailing(p.readObject(true))
 	if err == nil {
 		return res, nil
 	}
@@ -466,7 +465,7 @@ func Unmarshal(data []byte, v interface{}) (err error) {
 
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {
-		return errors.New("non-pointer " + reflect.TypeOf(v).String())
+		return fmt.Errorf("non-pointer %v", reflect.TypeOf(v))
 	}
 	for rv.Kind() == reflect.Ptr {
 		rv = rv.Elem()

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -106,7 +106,7 @@ func TestInvalidDestinationType(t *testing.T) {
 	}
 }
 
-func TestNilPointer(t *testing.T) {
+func TestNilValue(t *testing.T) {
 	var dat interface{}
 	err := Unmarshal([]byte(`[1,2,3,4]`), dat)
 	if err == nil {

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -105,3 +105,11 @@ func TestInvalidDestinationType(t *testing.T) {
 		panic("An error should occur")
 	}
 }
+
+func TestNilPointer(t *testing.T) {
+	var dat interface{}
+	err := Unmarshal([]byte(`[1,2,3,4]`), dat)
+	if err == nil {
+		panic("Passing v = <nil> to Unmarshal should return an error")
+	}
+}

--- a/parseNumber.go
+++ b/parseNumber.go
@@ -27,6 +27,14 @@ func (p *parseNumber) next() bool {
 	return false
 }
 
+func (p *parseNumber) peek(offs int) byte {
+	pos := p.at + offs
+	if pos >= 0 && pos < len(p.data) {
+		return p.data[pos]
+	}
+	return 0
+}
+
 func startsWithNumber(text []byte) bool {
 	if _, err := tryParseNumber(text, true); err == nil {
 		return true
@@ -81,7 +89,7 @@ func tryParseNumber(text []byte, stopAtNext bool) (float64, error) {
 	if stopAtNext {
 		// end scan if we find a punctuator character like ,}] or a comment
 		if p.ch == ',' || p.ch == '}' || p.ch == ']' ||
-			p.ch == '#' || p.ch == '/' && (p.data[p.at] == '/' || p.data[p.at] == '*') {
+			p.ch == '#' || p.ch == '/' && (p.peek(0) == '/' || p.peek(0) == '*') {
 			p.ch = 0
 		}
 	}


### PR DESCRIPTION
As per #16, `Unmarshal` panics when called with `v=nil`, so this PR aims to fix that. The new behavior can be seen at https://play.golang.org/p/uQDTVmAGRk_B, if there's anything missing just let me know