### PR TITLE
EOL defaults for Windows

### DIFF
--- a/defaults_others.go
+++ b/defaults_others.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package hjson
+
+const (
+	defaultEOL = "\n"
+)

--- a/defaults_windows.go
+++ b/defaults_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package hjson
+
+const (
+	defaultEOL = "\r\n"
+)

--- a/encode.go
+++ b/encode.go
@@ -35,7 +35,7 @@ type EncoderOptions struct {
 // DefaultOptions returns the default encoding options.
 func DefaultOptions() EncoderOptions {
 	opt := EncoderOptions{}
-	opt.Eol = "\n"
+	opt.Eol = defaultEOL
 	opt.BracesSameLine = false
 	opt.EmitRootBraces = true
 	opt.QuoteAlways = false


### PR DESCRIPTION
This defaults the EOL to `\r\n` on Windows. On other platforms the current default of `\n` is preserved.

I understand that this behaviour can be overridden already using `MarshalWithOptions`, but it feels like we should endeavour to do what is natural for a given platform by default without doing anything special, particularly since Notepad and friends on Windows have a hard time with `\n`.