### PR TITLE
Remove gomod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Build the ${{ runner.os }} hjson-cli binary
         run: |
           mkdir -p ~/go/src/github.com/hjson
-          ln -s $(pwd) ~/go/src/github.com/hjson/hjson-go
+          cd ..
+          cp -r hjson-go ~/go/src/github.com/hjson/
+          cd hjson-go
           mkdir binaries
           cd hjson-cli
           go build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-        run: |
-          mkdir -p ~/go/src/github.com/hjson
-          ln -s $(pwd) ~/go/src/github.com/hjson/hjson-go
           
       - name: Build the ${{ runner.os }} hjson-cli binary
         run: |
+          mkdir -p ~/go/src/github.com/hjson
+          ln -s $(pwd) ~/go/src/github.com/hjson/hjson-go
           mkdir binaries
           cd hjson-cli
           go build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+**'
 
+env:
+  GO111MODULE: auto
+
 jobs:
   
   build_hjson-cli_releases:
@@ -18,6 +21,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        run: |
+          mkdir -p ~/go/src/github.com/hjson
+          ln -s $(pwd) ~/go/src/github.com/hjson/hjson-go
           
       - name: Build the ${{ runner.os }} hjson-cli binary
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          cd ..
           mkdir -p ~/go/src/github.com/hjson
-          cp -r hjson-go ~/go/src/github.com/hjson/
+          ln -s $(pwd) ~/go/src/github.com/hjson/hjson-go
       - run: go version
+      - run: go test -v
       - run: |
-          cd ~/go/src/github.com/hjson/hjson-go
-          go test -v
-      - run: |
-          cd ~/go/src/github.com/hjson/hjson-go/hjson-cli
+          cd hjson-cli
           go install -i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,11 @@ jobs:
       - run: |
           cd ..
           mkdir -p ~/go/src/github.com/hjson
-          mv hjson-go ~/go/src/github.com/hjson/
-          cd ~/go/src/github.com/hjson
+          cp -r hjson-go ~/go/src/github.com/hjson/
       - run: go version
-      - run: go test -v
       - run: |
-          cd hjson-cli
+          cd ~/go/src/github.com/hjson/hjson-go
+          go test -v
+      - run: |
+          cd ~/go/src/github.com/hjson/hjson-go/hjson-cli
           go install -i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,5 @@ jobs:
       - run: go version
       - run: go test -v
       - run: |
-          cd hjson-cli
+          cd ~/go/src/github.com/hjson/hjson-go/hjson-cli
           go install -i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
+      - run: |
+          cd ..
+          mkdir -p ~/go/src/github.com/hjson
+          mv hjson-go ~/go/src/github.com/hjson/
+          cd ~/go/src/github.com/hjson
       - run: go version
       - run: go test -v
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: test
 on: [push, pull_request]
+env:
+  GO111MODULE: auto
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           mkdir -p ~/go/src/github.com/hjson
-          ln -s $(pwd) ~/go/src/github.com/hjson/hjson-go
+          cd ..
+          cp -r hjson-go ~/go/src/github.com/hjson/
       - run: go version
       - run: go test -v
       - run: |

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/hjson/hjson-go
-
-go 1.6


### PR DESCRIPTION
Fix for building version 3 of hjson-go. Requires `export GO111MODULE=auto` when building or testing using Go 1.16 or later.

Will create a new go.mod in version 4 of hjson-go.