### PR TITLE
Decode as string to string destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ func main() {
     a := foo{A: "hi!", B: 3, C: "some text", D: 5}
     buf, err := hjson.Marshal(a)
     if err != nil {
-        fmt.Error(err)
+        fmt.Println(err)
     }
 
     fmt.Println(string(buf))
@@ -226,6 +226,44 @@ Output:
   D: 5
 }
 ```
+
+# Type ambiguity
+
+Hjson allows quoteless strings. But if a value is a valid number, boolean or `null` then it will be unmarshalled into that type instead of a string when unmarshalling into `interface{}`. This can lead to unintended consequences if the creator of an Hjson file meant to write a string but didn't think of that the quoteless string they wrote also was a valid number.
+
+The ambiguity can be avoided by using typed destinations when unmarshalling. A string destination will receive a string even if the quoteless string also was a valid number, boolean or `null`. Example:
+
+```go
+
+package main
+
+import (
+    "github.com/hjson/hjson-go/v4"
+    "fmt"
+)
+
+type foo struct {
+  A string
+}
+
+func main() {
+    var dest foo
+    err := hjson.Unmarshal([]byte(`a: 3`), &dest)
+    if err != nil {
+        fmt.Println(err)
+    }
+
+    fmt.Println(dest)
+}
+```
+
+Output:
+
+```
+{3}
+```
+
+String pointer destinations are treated the same as string destinations, so you cannot set a string pointer to `nil` by writing `null` in an Hjson file. Writing `null` in an Hjson file would result in the string "null" being stored in the destination string pointer.
 
 # API
 

--- a/decode.go
+++ b/decode.go
@@ -297,6 +297,17 @@ func (p *hjsonParser) readTfnns(dest reflect.Value) (interface{}, error) {
 	value := new(bytes.Buffer)
 	value.WriteByte(p.ch)
 
+	for a := 0; a < maxPointerDepth && (dest.Kind() == reflect.Ptr ||
+		dest.Kind() == reflect.Interface); a++ {
+
+		if dest.IsZero() {
+			if dest.Kind() == reflect.Interface {
+				break
+			}
+		}
+		dest = dest.Elem()
+	}
+
 	for {
 		p.next()
 		isEol := p.ch == '\r' || p.ch == '\n' || p.ch == 0
@@ -352,6 +363,17 @@ func (p *hjsonParser) readArray(dest reflect.Value) (value interface{}, err erro
 	if p.ch == ']' {
 		p.next()
 		return array, nil // empty array
+	}
+
+	for a := 0; a < maxPointerDepth && (dest.Kind() == reflect.Ptr ||
+		dest.Kind() == reflect.Interface); a++ {
+
+		if dest.IsZero() {
+			if dest.Kind() == reflect.Interface {
+				break
+			}
+		}
+		dest = dest.Elem()
 	}
 
 	// All elements in any existing slice/array will be removed, so we only care

--- a/decode.go
+++ b/decode.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-const maxPointerDepth = 5
+const maxPointerDepth = 512
 
 // DecoderOptions defines options for decoding Hjson.
 type DecoderOptions struct {

--- a/decode.go
+++ b/decode.go
@@ -338,9 +338,11 @@ func (p *hjsonParser) readTfnns(dest reflect.Value, t reflect.Type) (interface{}
 			p.ch == '/' && (p.peek(0) == '/' || p.peek(0) == '*') {
 
 			// Do not output anything else than a string if our destination is a string.
+			// Pointer methods can be called if the destination is addressable,
+			// therefore we also check if dest.Addr() implements encoding.TextUnmarshaler.
 			if (newT == nil || newT.Kind() != reflect.String) &&
 				(t == nil || !(t.Implements(unmarshalerText) ||
-					reflect.New(t).Type().Implements(unmarshalerText))) {
+					dest.CanAddr() && dest.Addr().Type().Implements(unmarshalerText))) {
 
 				switch chf {
 				case 'f':

--- a/decode.go
+++ b/decode.go
@@ -380,23 +380,14 @@ func (p *hjsonParser) readArray(dest reflect.Value, t reflect.Type) (value inter
 
 	// All elements in any existing slice/array will be removed, so we only care
 	// about the type of the new elements that will be created.
-	if t != nil {
-		for a := 0; a < maxPointerDepth; a++ {
-			if t == nil {
-				break
-			}
-			switch t.Kind() {
-			case reflect.Ptr, reflect.Slice, reflect.Array:
-				t = t.Elem()
-			default:
-				break
-			}
-		}
+	var newDestType reflect.Type
+	if t != nil && (t.Kind() == reflect.Slice || t.Kind() == reflect.Array) {
+		newDestType = t.Elem()
 	}
 
 	for p.ch > 0 {
 		var val interface{}
-		if val, err = p.readValue(reflect.Value{}, t); err != nil {
+		if val, err = p.readValue(reflect.Value{}, newDestType); err != nil {
 			return nil, err
 		}
 		array = append(array, val)

--- a/decode.go
+++ b/decode.go
@@ -443,7 +443,25 @@ func (p *hjsonParser) readObject(withoutBraces bool, dest reflect.Value) (value 
 			}
 
 		case reflect.Map:
-			if t.Key().Kind() == reflect.String {
+			validKeyType := false
+
+			// Map key must either have string kind, have an integer kind,
+			// or be an encoding.TextUnmarshaler.
+			switch t.Key().Kind() {
+			case reflect.String,
+				reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+				reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+				reflect.Uintptr:
+
+				validKeyType = true
+
+			default:
+				if reflect.PointerTo(t.Key()).Implements(marshalerText) {
+					validKeyType = true
+				}
+			}
+
+			if validKeyType {
 				destIsMap = true
 
 				t = t.Elem()

--- a/decode.go
+++ b/decode.go
@@ -103,7 +103,7 @@ var escapee = map[byte]byte{
 func unravelDestination(dest reflect.Value, t reflect.Type) (reflect.Value, reflect.Type) {
 	if dest.IsValid() {
 		for a := 0; a < maxPointerDepth && (dest.Kind() == reflect.Ptr ||
-			dest.Kind() == reflect.Interface) && !dest.IsZero(); a++ {
+			dest.Kind() == reflect.Interface) && !dest.IsNil(); a++ {
 
 			dest = dest.Elem()
 		}
@@ -474,10 +474,10 @@ func (p *hjsonParser) readObject(
 				newDest, newDestType = dest, t
 				for _, i := range sfi.indexPath {
 					if newDest.IsValid() {
-						if newDest.IsZero() {
+						if newDest.Kind() != reflect.Struct {
 							// We are only keeping track of newDest in case it contains a
-							// tree that we will partially update. But here we have found
-							// a zero-value, so we can ignore newDest and just look at
+							// tree that we will partially update. But here we have not found
+							// any tree, so we can ignore newDest and just look at
 							// newDestType instead.
 							newDest = reflect.Value{}
 						} else {
@@ -574,7 +574,6 @@ func (p *hjsonParser) checkTrailing(v interface{}, err error) (interface{}, erro
 // result in the value pointed to by v.
 //
 // See UnmarshalWithOptions.
-//
 func Unmarshal(data []byte, v interface{}) error {
 	return UnmarshalWithOptions(data, v, DefaultDecoderOptions())
 }

--- a/decode.go
+++ b/decode.go
@@ -2,6 +2,7 @@ package hjson
 
 import (
 	"bytes"
+	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,6 +22,8 @@ type DecoderOptions struct {
 	// non-ignored, exported fields in the destination.
 	DisallowUnknownFields bool
 }
+
+var unmarshalerText = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
 
 // DefaultDecoderOptions returns the default decoding options.
 func DefaultDecoderOptions() DecoderOptions {
@@ -328,7 +331,9 @@ func (p *hjsonParser) readTfnns(dest reflect.Value, t reflect.Type) (interface{}
 			p.ch == '/' && (p.peek(0) == '/' || p.peek(0) == '*') {
 
 			// Do not output anything else than a string if our destination is a string.
-			if t == nil || t.Kind() != reflect.String {
+			if t == nil || (t.Kind() != reflect.String && !t.Implements(unmarshalerText) &&
+				!reflect.PointerTo(t).Implements(unmarshalerText)) {
+
 				switch chf {
 				case 'f':
 					if strings.TrimSpace(value.String()) == "false" {

--- a/decode.go
+++ b/decode.go
@@ -301,11 +301,17 @@ func (p *hjsonParser) readTfnns(dest reflect.Value) (interface{}, error) {
 		dest.Kind() == reflect.Interface); a++ {
 
 		if dest.IsZero() {
-			if dest.Kind() == reflect.Interface {
-				break
-			}
+			break
 		}
 		dest = dest.Elem()
+	}
+
+	var t reflect.Type
+	if dest.IsValid() {
+		t = dest.Type()
+		for a := 0; a < maxPointerDepth && t != nil && t.Kind() == reflect.Ptr; a++ {
+			t = t.Elem()
+		}
 	}
 
 	for {
@@ -317,7 +323,7 @@ func (p *hjsonParser) readTfnns(dest reflect.Value) (interface{}, error) {
 			p.ch == '/' && (p.peek(0) == '/' || p.peek(0) == '*') {
 
 			// Do not output anything else than a string if our destination is a string.
-			if !dest.IsValid() || dest.Kind() != reflect.String {
+			if t == nil || t.Kind() != reflect.String {
 				switch chf {
 				case 'f':
 					if strings.TrimSpace(value.String()) == "false" {

--- a/decode.go
+++ b/decode.go
@@ -419,8 +419,13 @@ func (p *hjsonParser) readObject(withoutBraces bool, dest reflect.Value) (value 
 	destIsMap := false
 	var mapDefaultDest reflect.Value
 	if dest.IsValid() {
-		for a := 0; a < maxPointerDepth && dest.Kind() == reflect.Ptr; a++ {
+		for a := 0; a < maxPointerDepth && (dest.Kind() == reflect.Ptr ||
+			dest.Kind() == reflect.Interface); a++ {
+
 			if dest.IsZero() {
+				if dest.Kind() == reflect.Interface {
+					break
+				}
 				dest = reflect.New(dest.Type().Elem())
 			}
 			dest = dest.Elem()

--- a/decode.go
+++ b/decode.go
@@ -331,8 +331,8 @@ func (p *hjsonParser) readTfnns(dest reflect.Value, t reflect.Type) (interface{}
 			p.ch == '/' && (p.peek(0) == '/' || p.peek(0) == '*') {
 
 			// Do not output anything else than a string if our destination is a string.
-			if t == nil || (t.Kind() != reflect.String && !t.Implements(unmarshalerText) &&
-				!reflect.PointerTo(t).Implements(unmarshalerText)) {
+			if t == nil || !(t.Kind() == reflect.String || t.Implements(unmarshalerText) ||
+				reflect.New(t).Type().Implements(unmarshalerText)) {
 
 				switch chf {
 				case 'f':

--- a/encode.go
+++ b/encode.go
@@ -373,7 +373,7 @@ func (e *hjsonEncoder) str(value reflect.Value, noIndent bool, separator string,
 		t := value.Type()
 		sfis, ok := e.structTypeCache[t]
 		if !ok {
-			sfis = getStructFieldInfo(t)
+			sfis = getStructFieldInfoSlice(t)
 			e.structTypeCache[t] = sfis
 		}
 

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -455,6 +455,65 @@ five: {
 	}
 }
 
+type itsF struct {
+	itsG
+	F string
+}
+
+type itsG struct {
+	*itsH
+	G string
+}
+
+type itsH struct {
+	itsI
+	H string
+}
+
+type itsI struct {
+	I string
+}
+
+func TestEmbeddedStructTree(t *testing.T) {
+	textA := []byte(`
+f: 1.5
+g: true
+h: null
+i: false
+`)
+
+	sA := itsF{
+		itsG: itsG{
+			itsH: &itsH{},
+		},
+	}
+	err := Unmarshal(textA, &sA)
+	if err != nil {
+		t.Error(err)
+	} else {
+		buf, err := json.MarshalIndent(sA, "", "  ")
+		if err != nil {
+			t.Error(err)
+		}
+		// Note that only the field Sub2 was replaced by textB in the tsB struct.
+		// The field Sub1 still has the value that was set by textA.
+		if !reflect.DeepEqual(sA, itsF{
+			F: "1.5",
+			itsG: itsG{
+				G: "true",
+				itsH: &itsH{
+					H: "null",
+					itsI: itsI{
+						I: "false",
+					},
+				},
+			},
+		}) {
+			t.Errorf("Unexpected struct values:\n%v\n", string(buf))
+		}
+	}
+}
+
 type InterfaceA interface {
 	FuncA() string
 }

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -675,3 +675,24 @@ two: {
 		}
 	}
 }
+
+func TestFieldCase(t *testing.T) {
+	type tsA struct {
+		Field int
+		FiEld int
+		FieLd string
+		FielD int
+	}
+
+	textA := []byte(`
+FieLd: 3
+`)
+
+	var sA tsA
+	err := Unmarshal(textA, &sA)
+	if err != nil {
+		t.Error(err)
+	} else if sA.FieLd != "3" {
+		t.Errorf("Unexpected struct values:\n%#v\n", sA)
+	}
+}

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -811,4 +811,20 @@ e: 7
 	}) {
 		t.Errorf("Unexpected struct values:\n%#v\n", sA)
 	}
+
+	textB := []byte(`8`)
+
+	var sL itsL
+	err = Unmarshal(textB, &sL)
+	if err != nil {
+		t.Error(err)
+	} else if sL != itsL(textB[0]) {
+		t.Errorf("Unexpected sL value: %v\n", sL)
+	}
+
+	var m map[string]itsL
+	err = Unmarshal(textA, &m)
+	if err == nil {
+		t.Error("Should have failed, should not be possible to call pointer method UnmarshalText() on the map elements because they are not addressable.")
+	}
 }

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -267,5 +268,86 @@ func TestJSONNumber(t *testing.T) {
 	_, err = n.Int64()
 	if err == nil {
 		t.Errorf("Did not expect %v to be parsable to int64", n)
+	}
+}
+
+func TestMapKeys(t *testing.T) {
+	sampleText := []byte(`
+4: four
+3: true
+2: 2
+1: null
+`)
+
+	{
+		var v map[string]interface{}
+		err := Unmarshal(sampleText, &v)
+		if err != nil {
+			t.Error(err)
+		} else {
+			if v["3"] != true {
+				t.Errorf("Expected boolean, got %v", reflect.TypeOf(v["3"]))
+			}
+			if v["2"] != 2.0 {
+				t.Errorf("Expected float64, got %v", reflect.TypeOf(v["2"]))
+			}
+			if v["1"] != nil {
+				t.Errorf("Expected nil-interface, got %v", reflect.TypeOf(v["1"]))
+			}
+		}
+	}
+
+	{
+		var v map[int]interface{}
+		err := Unmarshal(sampleText, &v)
+		if err != nil {
+			t.Error(err)
+		} else {
+			if v[3] != true {
+				t.Errorf("Expected boolean, got %v", reflect.TypeOf(v[3]))
+			}
+			if v[2] != 2.0 {
+				t.Errorf("Expected float64, got %v", reflect.TypeOf(v[2]))
+			}
+			if v[1] != nil {
+				t.Errorf("Expected nil-interface, got %v", reflect.TypeOf(v[1]))
+			}
+		}
+	}
+
+	{
+		var v map[string]string
+		err := Unmarshal(sampleText, &v)
+		if err != nil {
+			t.Error(err)
+		} else {
+			if v["3"] != "true" {
+				t.Errorf("Expected true, got %v", v["3"])
+			}
+			if v["2"] != "2" {
+				t.Errorf("Expected 2, got %v", v["2"])
+			}
+			if v["1"] != "null" {
+				t.Errorf("Expected null, got %v", v["1"])
+			}
+		}
+	}
+
+	{
+		var v map[int]string
+		err := Unmarshal(sampleText, &v)
+		if err != nil {
+			t.Error(err)
+		} else {
+			if v[3] != "true" {
+				t.Errorf("Expected true, got %v", v[3])
+			}
+			if v[2] != "2" {
+				t.Errorf("Expected 2, got %v", v[2])
+			}
+			if v[1] != "null" {
+				t.Errorf("Expected null, got %v", v[1])
+			}
+		}
 	}
 }

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -468,7 +468,7 @@ type itsA struct {
 	One   *int
 	Two   int
 	Three bool
-	Four  string
+	Four  *string
 	Five  InterfaceA
 }
 
@@ -477,12 +477,12 @@ func (c *itsB) FuncA() string {
 }
 
 func (c *itsA) FuncA() string {
-	return c.Four
+	return *c.Four
 }
 
 func TestStructInterface(t *testing.T) {
 	textA := []byte(`
-four: four
+four: 4
 three: true
 five: {
   sub1: 1
@@ -493,7 +493,7 @@ one: null
 `)
 
 	textB := []byte(`
-four: five
+four: 5
 five: {
 	sub2: 3
 }
@@ -511,13 +511,14 @@ five: {
 	if err != nil {
 		t.Error(err)
 	} else {
+		five := "5"
 		// Note that only the field Sub2 was replaced by textB in the tsB struct.
 		// The field Sub1 still has the value that was set by textA.
 		if !reflect.DeepEqual(sA, itsA{
 			One:   nil,
 			Two:   2,
 			Three: true,
-			Four:  "five",
+			Four:  &five,
 			Five: &itsB{
 				Sub1: "1",
 				Sub2: "3",
@@ -546,6 +547,20 @@ func TestStringInterface(t *testing.T) {
 	} else {
 		if string(sA) != "3" {
 			t.Errorf("Unexpected string value:\n%v\n", sA)
+		}
+	}
+}
+
+func TestStringPointer(t *testing.T) {
+	textA := []byte(`3`)
+
+	var psA *itsC
+	err := Unmarshal(textA, &psA)
+	if err != nil {
+		t.Error(err)
+	} else {
+		if string(*psA) != "3" {
+			t.Errorf("Unexpected string value:\n%v\n", *psA)
 		}
 	}
 }

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -585,3 +585,78 @@ func TestSliceInterface(t *testing.T) {
 		}
 	}
 }
+
+type InterfaceB interface{}
+
+func TestNilInterfaces(t *testing.T) {
+	textA := []byte(`
+[
+	3
+	alfa
+	5
+]
+`)
+
+	textB := []byte(`
+four: five
+five: {
+	sub2: 3
+}
+`)
+
+	var isA InterfaceA
+	err := Unmarshal(textA, &isA)
+	if err == nil {
+		// If the interface has at least one function it must not be empty.
+		t.Error("Unmarshal into empty InterfaceA did not return error")
+	}
+
+	var isB InterfaceB
+	err = Unmarshal(textA, &isB)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var isC interface{}
+	err = Unmarshal(textA, &isC)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var isD itsA
+	err = Unmarshal(textB, &isD)
+	if err == nil {
+		// If the interface has at least one function it must not be empty.
+		t.Error("Unmarshal into empty InterfaceA did not return error")
+	}
+}
+
+type itsE struct {
+	One string
+	Two *itsB
+}
+
+func TestStructPointer(t *testing.T) {
+	textA := []byte(`
+one: 1
+two: {
+	sub2: 3
+}
+`)
+
+	var psA *itsE
+	err := Unmarshal(textA, &psA)
+	if err != nil {
+		t.Error(err)
+	} else {
+		if !reflect.DeepEqual(psA, &itsE{
+			One: "1",
+			Two: &itsB{
+				Sub2: "3",
+			},
+		}) {
+			buf, _ := json.Marshal(psA)
+			t.Errorf("Unexpected struct values:\n%v\n", string(buf))
+		}
+	}
+}


### PR DESCRIPTION
If the destination is a string, Unmarshal() now stores the value as a string even if it is a valid number, boolean or "null". Previously an error was returned ("cannot store a number as type string" etc).