### PR TITLE
ElemTyper, key order

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Output:
 }
 ```
 
-# Type ambiguity
+## Type ambiguity
 
 Hjson allows quoteless strings. But if a value is a valid number, boolean or `null` then it will be unmarshalled into that type instead of a string when unmarshalling into `interface{}`. This can lead to unintended consequences if the creator of an Hjson file meant to write a string but didn't think of that the quoteless string they wrote also was a valid number.
 
@@ -264,6 +264,19 @@ Output:
 ```
 
 String pointer destinations are treated the same as string destinations, so you cannot set a string pointer to `nil` by writing `null` in an Hjson file. Writing `null` in an Hjson file would result in the string "null" being stored in the destination string pointer.
+
+## ElemTyper interface
+
+If a destination type implements hjson.ElemTyper, Unmarshal() will call ElemType() on the destination when unmarshalling an array or an object, to see if any array element or leaf node should be of type string even if it can be treated as a number, boolean or null. This is most useful if the destination also implements the json.Unmarshaler interface, because then there is no other way for Unmarshal() to know the type of the elements on the destination. If a destination implements ElemTyper all of its elements must be of the same type.
+
+Example implementation for a generic ordered map:
+
+```go
+
+func (o *OrderedMap[T]) ElemType() reflect.Type {
+  return reflect.TypeOf((*T)(nil)).Elem()
+}
+```
 
 # API
 

--- a/decode.go
+++ b/decode.go
@@ -405,7 +405,7 @@ func (p *hjsonParser) readArray(dest reflect.Value, t reflect.Type) (value inter
 	// t must not have been unraveled
 	if t != nil && t.Implements(elemTyper) {
 		rv := dest
-		if t.Kind() == reflect.Pointer {
+		if t.Kind() == reflect.Ptr {
 			// If ElemType() has a value receiver we would get a panic if we call it
 			// on a nil pointer.
 			if !rv.IsValid() || rv.IsNil() {
@@ -477,7 +477,7 @@ func (p *hjsonParser) readObject(
 
 		if t != nil && t.Implements(elemTyper) {
 			isElemTyper = true
-			if t.Kind() == reflect.Pointer {
+			if t.Kind() == reflect.Ptr {
 				// If ElemType() has a value receiver we would get a panic if we call it
 				// on a nil pointer.
 				if !rv.IsValid() || rv.IsNil() {

--- a/decode.go
+++ b/decode.go
@@ -429,7 +429,7 @@ func (p *hjsonParser) readObject(
 ) (value interface{}, err error) {
 	// Parse an object value.
 
-	object := make(map[string]interface{})
+	var object orderedMap
 
 	if !withoutBraces {
 		// assuming ch == '{'
@@ -508,7 +508,7 @@ func (p *hjsonParser) readObject(
 		if val, err = p.readValue(newDest, newDestType); err != nil {
 			return nil, err
 		}
-		object[key] = val
+		object = append(object, keyVal{key, val})
 		p.white()
 		// in Hjson the comma is optional and trailing commas are allowed
 		if p.ch == ',' {

--- a/decode.go
+++ b/decode.go
@@ -13,7 +13,7 @@ import (
 const maxPointerDepth = 512
 
 // If a destination type implements ElemTyper, Unmarshal() will call ElemType()
-// on the destination when unmarshaling an array or an object, to see if any
+// on the destination when unmarshalling an array or an object, to see if any
 // array element or leaf node should be of type string even if it can be treated
 // as a number, boolean or null. This is most useful if the destination also
 // implements the json.Unmarshaler interface, because then there is no other way
@@ -21,7 +21,8 @@ const maxPointerDepth = 512
 // destination implements ElemTyper all of its elements must be of the same
 // type.
 type ElemTyper interface {
-	// Returns the desired type of any elements.
+	// Returns the desired type of any elements. If ElemType() is implemented
+	// using a pointer receiver it must be possible to call with nil as receiver.
 	ElemType() reflect.Type
 }
 

--- a/decode.go
+++ b/decode.go
@@ -12,7 +12,16 @@ import (
 
 const maxPointerDepth = 512
 
+// If a destination of kind slice, array, map or struct implements ElemTyper
+// Unmarshal() will call ElemType() on the destination to see if any leaf node
+// should be of type string even if it can be treated as a number, boolean or
+// null. This is most useful if the destination also implements the
+// json.Unmarshaler interface, because then there is no other way for
+// Unmarshal() to know the type of the elements on the destination. If a
+// destination implements ElemTyper all of its elements must be of the same
+// type.
 type ElemTyper interface {
+	// Returns the type of any elements.
 	ElemType() reflect.Type
 }
 

--- a/encode.go
+++ b/encode.go
@@ -244,6 +244,12 @@ func (e *hjsonEncoder) str(value reflect.Value, noIndent bool, separator string,
 		defer func() { e.pDepth-- }()
 	}
 
+	if !value.IsValid() {
+		e.WriteString(separator)
+		e.WriteString("null")
+		return nil
+	}
+
 	if kind == reflect.Interface || kind == reflect.Ptr {
 		if value.IsNil() {
 			e.WriteString(separator)

--- a/encode.go
+++ b/encode.go
@@ -207,8 +207,10 @@ func (e *hjsonEncoder) useMarshalerJSON(
 		return err
 	}
 
-	var jsonRoot interface{}
-	err = Unmarshal(b, &jsonRoot)
+	decOpt := DefaultDecoderOptions()
+	decOpt.UseJSONNumber = true
+	var dummyDest interface{}
+	jsonRoot, err := orderedUnmarshal(b, &dummyDest, decOpt)
 	if err != nil {
 		return err
 	}
@@ -249,6 +251,20 @@ func (e *hjsonEncoder) str(value reflect.Value, noIndent bool, separator string,
 			return nil
 		}
 		return e.str(value.Elem(), noIndent, separator, isRootObject)
+	}
+
+	// Our internal orderedMap implements marshalerJSON. We must therefore place
+	// this check before checking marshalerJSON. Calling orderedMap.MarshalJSON()
+	// from this function would cause an infinite loop.
+	if om, ok := value.Interface().(orderedMap); ok {
+		var fis []fieldInfo
+		for _, elem := range om {
+			fis = append(fis, fieldInfo{
+				field: reflect.ValueOf(elem.value),
+				name:  elem.key,
+			})
+		}
+		return e.writeFields(fis, noIndent, separator, isRootObject)
 	}
 
 	if value.Type().Implements(marshalerJSON) {
@@ -436,7 +452,6 @@ func isEmptyValue(v reflect.Value) bool {
 // default options.
 //
 // See MarshalWithOptions.
-//
 func Marshal(v interface{}) ([]byte, error) {
 	return MarshalWithOptions(v, DefaultOptions())
 }
@@ -490,29 +505,29 @@ func Marshal(v interface{}) ([]byte, error) {
 //
 // Examples of struct field tags and their meanings:
 //
-//   // Field appears in Hjson as key "myName".
-//   Field int `json:"myName"`
+//	// Field appears in Hjson as key "myName".
+//	Field int `json:"myName"`
 //
-//   // Field appears in Hjson as key "myName" and the field is omitted from
-//   // the object if its value is empty, as defined above.
-//   Field int `json:"myName,omitempty"`
+//	// Field appears in Hjson as key "myName" and the field is omitted from
+//	// the object if its value is empty, as defined above.
+//	Field int `json:"myName,omitempty"`
 //
-//   // Field appears in Hjson as key "Field" (the default), but the field is
-//   // skipped if empty. Note the leading comma.
-//   Field int `json:",omitempty"`
+//	// Field appears in Hjson as key "Field" (the default), but the field is
+//	// skipped if empty. Note the leading comma.
+//	Field int `json:",omitempty"`
 //
-//   // Field is ignored by this package.
-//   Field int `json:"-"`
+//	// Field is ignored by this package.
+//	Field int `json:"-"`
 //
-//   // Field appears in Hjson as key "-".
-//   Field int `json:"-,"`
+//	// Field appears in Hjson as key "-".
+//	Field int `json:"-,"`
 //
-//   // Field appears in Hjson preceded by a line just containing `# A comment.`
-//   Field int `comment:"A comment."`
+//	// Field appears in Hjson preceded by a line just containing `# A comment.`
+//	Field int `comment:"A comment."`
 //
-//   // Field appears in Hjson as key "myName" preceded by a line just
-//   // containing `# A comment.`
-//   Field int `json:"myName" comment:"A comment."`
+//	// Field appears in Hjson as key "myName" preceded by a line just
+//	// containing `# A comment.`
+//	Field int `json:"myName" comment:"A comment."`
 //
 // Anonymous struct fields are usually marshaled as if their inner exported fields
 // were fields in the outer struct, subject to the usual Go visibility rules amended
@@ -554,7 +569,6 @@ func Marshal(v interface{}) ([]byte, error) {
 //
 // Hjson cannot represent cyclic data structures and Marshal does not handle
 // them. Passing cyclic structures to Marshal will result in an error.
-//
 func MarshalWithOptions(v interface{}, options EncoderOptions) ([]byte, error) {
 	e := &hjsonEncoder{
 		indent:          0,

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -294,6 +294,18 @@ func (c *testOrderedMapB) ElemType() reflect.Type {
 	return reflect.TypeOf("")
 }
 
+type testSliceElemTyperA []interface{}
+
+func (c testSliceElemTyperA) ElemType() reflect.Type {
+	return reflect.TypeOf("")
+}
+
+type testSliceElemTyperB []interface{}
+
+func (c *testSliceElemTyperB) ElemType() reflect.Type {
+	return reflect.TypeOf("")
+}
+
 func TestUnmarshalInterface(t *testing.T) {
 	txt := []byte(`{
   B: first
@@ -411,7 +423,7 @@ func TestUnmarshalInterfaceElemType(t *testing.T) {
 	}
 }
 
-func TestUnmarshalSliceElemType(t *testing.T) {
+func TestUnmarshalSliceMapElemType(t *testing.T) {
 	txt := []byte(`[
   {
     B: first
@@ -491,7 +503,7 @@ func TestUnmarshalSliceElemType(t *testing.T) {
 	}
 }
 
-func TestUnmarshalSlicePointerElemType(t *testing.T) {
+func TestUnmarshalSliceMapPointerElemType(t *testing.T) {
 	txt := []byte(`[
   {
     B: first
@@ -736,6 +748,321 @@ func TestUnmarshalStructPointerElemType(t *testing.T) {
 			orderedMap{
 				{"D", "3"},
 			},
+		},
+	}
+	if !reflect.DeepEqual(objB, expectedB) {
+		t.Errorf("Unexpected obj: %#v\n", objB)
+	}
+
+	objB = tsB{}
+	pObjB := &objB
+	err = Unmarshal(txt, &pObjB)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(objB, expectedB) {
+		t.Errorf("Unexpected obj: %#v\n", objB)
+	}
+}
+
+func TestUnmarshalSliceElemType(t *testing.T) {
+	txt := []byte(`[
+	1
+	two
+]`)
+
+	var objA testSliceElemTyperA
+	err := Unmarshal(txt, &objA)
+	if err != nil {
+		t.Error(err)
+	}
+	// Make sure that all values are strings (because of testSliceElemTyper.ElemType()).
+	expectedA := testSliceElemTyperA{
+		"1",
+		"two",
+	}
+	if !reflect.DeepEqual(objA, expectedA) {
+		t.Errorf("Unexpected obj: %#v\n", objA)
+	}
+
+	objA = nil
+	pObjA := &objA
+	err = Unmarshal(txt, &pObjA)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(objA, expectedA) {
+		t.Errorf("Unexpected obj: %#v\n", objA)
+	}
+
+	var objB testSliceElemTyperB
+	err = Unmarshal(txt, &objB)
+	if err != nil {
+		t.Error(err)
+	}
+	// Make sure that all values are strings (because of testOrderedMap.ElemType()).
+	expectedB := testSliceElemTyperB{
+		"1",
+		"two",
+	}
+	if !reflect.DeepEqual(objB, expectedB) {
+		t.Errorf("Unexpected obj: %#v\n", objB)
+	}
+
+	objB = nil
+	pObjB := &objB
+	err = Unmarshal(txt, &pObjB)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(objB, expectedB) {
+		t.Errorf("Unexpected obj: %#v\n", objB)
+	}
+}
+
+func TestUnmarshalSliceSliceElemType(t *testing.T) {
+	txt := []byte(`[
+  [
+    1
+    two
+  ]
+]`)
+
+	var objA []testSliceElemTyperA
+	err := Unmarshal(txt, &objA)
+	if err != nil {
+		t.Error(err)
+	}
+	// Make sure that all values are strings (because of testSliceElemTyper.ElemType()).
+	expectedA := []testSliceElemTyperA{
+		testSliceElemTyperA{
+			"1",
+			"two",
+		},
+	}
+	if !reflect.DeepEqual(objA, expectedA) {
+		t.Errorf("Unexpected obj: %#v\n", objA)
+	}
+
+	objA = nil
+	pObjA := &objA
+	err = Unmarshal(txt, &pObjA)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(objA, expectedA) {
+		t.Errorf("Unexpected obj: %#v\n", objA)
+	}
+
+	var objB []testSliceElemTyperB
+	err = Unmarshal(txt, &objB)
+	if err != nil {
+		t.Error(err)
+	}
+	// Make sure that all values are strings (because of testOrderedMap.ElemType()).
+	expectedB := []testSliceElemTyperB{
+		testSliceElemTyperB{
+			"1",
+			"two",
+		},
+	}
+	if !reflect.DeepEqual(objB, expectedB) {
+		t.Errorf("Unexpected obj: %#v\n", objB)
+	}
+
+	objB = nil
+	pObjB := &objB
+	err = Unmarshal(txt, &pObjB)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(objB, expectedB) {
+		t.Errorf("Unexpected obj: %#v\n", objB)
+	}
+}
+
+func TestUnmarshalSlicePointerSliceElemType(t *testing.T) {
+	txt := []byte(`[
+  [
+    1
+    two
+  ]
+]`)
+
+	var objA []*testSliceElemTyperA
+	err := Unmarshal(txt, &objA)
+	if err != nil {
+		t.Error(err)
+	}
+	// Make sure that all values are strings (because of testSliceElemTyper.ElemType()).
+	expectedA := []*testSliceElemTyperA{
+		&testSliceElemTyperA{
+			"1",
+			"two",
+		},
+	}
+	if !reflect.DeepEqual(objA, expectedA) {
+		t.Errorf("Unexpected obj: %#v\n", objA)
+	}
+
+	objA = nil
+	pObjA := &objA
+	err = Unmarshal(txt, &pObjA)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(objA, expectedA) {
+		t.Errorf("Unexpected obj: %#v\n", objA)
+	}
+
+	var objB []*testSliceElemTyperB
+	err = Unmarshal(txt, &objB)
+	if err != nil {
+		t.Error(err)
+	}
+	// Make sure that all values are strings (because of testOrderedMap.ElemType()).
+	expectedB := []*testSliceElemTyperB{
+		&testSliceElemTyperB{
+			"1",
+			"two",
+		},
+	}
+	if !reflect.DeepEqual(objB, expectedB) {
+		t.Errorf("Unexpected obj: %#v\n", objB)
+	}
+
+	objB = nil
+	pObjB := &objB
+	err = Unmarshal(txt, &pObjB)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(objB, expectedB) {
+		t.Errorf("Unexpected obj: %#v\n", objB)
+	}
+}
+
+func TestUnmarshalStructSliceElemType(t *testing.T) {
+	txt := []byte(`{
+  Key1: [
+    1
+    two
+  ]
+}`)
+
+	type tsA struct {
+		Key1 testSliceElemTyperA
+	}
+
+	var objA tsA
+	err := Unmarshal(txt, &objA)
+	if err != nil {
+		t.Error(err)
+	}
+	// Make sure that all values are strings (because of testSliceElemTyper.ElemType()).
+	expectedA := tsA{
+		Key1: testSliceElemTyperA{
+			"1",
+			"two",
+		},
+	}
+	if !reflect.DeepEqual(objA, expectedA) {
+		t.Errorf("Unexpected obj: %#v\n", objA)
+	}
+
+	objA = tsA{}
+	pObjA := &objA
+	err = Unmarshal(txt, &pObjA)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(objA, expectedA) {
+		t.Errorf("Unexpected obj: %#v\n", objA)
+	}
+
+	type tsB struct {
+		Key1 testSliceElemTyperB
+	}
+
+	var objB tsB
+	err = Unmarshal(txt, &objB)
+	if err != nil {
+		t.Error(err)
+	}
+	// Make sure that all values are strings (because of testOrderedMap.ElemType()).
+	expectedB := tsB{
+		Key1: testSliceElemTyperB{
+			"1",
+			"two",
+		},
+	}
+	if !reflect.DeepEqual(objB, expectedB) {
+		t.Errorf("Unexpected obj: %#v\n", objB)
+	}
+
+	objB = tsB{}
+	pObjB := &objB
+	err = Unmarshal(txt, &pObjB)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(objB, expectedB) {
+		t.Errorf("Unexpected obj: %#v\n", objB)
+	}
+}
+
+func TestUnmarshalStructPointerSliceElemType(t *testing.T) {
+	txt := []byte(`{
+  Key1: [
+    1
+    two
+  ]
+}`)
+
+	type tsA struct {
+		Key1 *testSliceElemTyperA
+	}
+
+	var objA tsA
+	err := Unmarshal(txt, &objA)
+	if err != nil {
+		t.Error(err)
+	}
+	// Make sure that all values are strings (because of testSliceElemTyper.ElemType()).
+	expectedA := tsA{
+		Key1: &testSliceElemTyperA{
+			"1",
+			"two",
+		},
+	}
+	if !reflect.DeepEqual(objA, expectedA) {
+		t.Errorf("Unexpected obj: %#v\n", objA)
+	}
+
+	objA = tsA{}
+	pObjA := &objA
+	err = Unmarshal(txt, &pObjA)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(objA, expectedA) {
+		t.Errorf("Unexpected obj: %#v\n", objA)
+	}
+
+	type tsB struct {
+		Key1 *testSliceElemTyperB
+	}
+
+	var objB tsB
+	err = Unmarshal(txt, &objB)
+	if err != nil {
+		t.Error(err)
+	}
+	// Make sure that all values are strings (because of testOrderedMap.ElemType()).
+	expectedB := tsB{
+		Key1: &testSliceElemTyperB{
+			"1",
+			"two",
 		},
 	}
 	if !reflect.DeepEqual(objB, expectedB) {

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -240,8 +240,8 @@ func (c *orderedMap) UnmarshalJSON(in []byte) error {
 
 func TestUnmarshalInterface(t *testing.T) {
 	txt := []byte(`{
-	B: first
-	A: second
+  B: first
+  A: second
 }`)
 	var obj orderedMap
 	err := Unmarshal(txt, &obj)

--- a/hjson_test.go
+++ b/hjson_test.go
@@ -230,8 +230,8 @@ func (c *orderedMap) UnmarshalJSON(in []byte) error {
 		index = i4 + 1
 
 		*c = append(*c, keyVal{
-			in[i1+1 : i2],
-			in[i3+1 : i4],
+			string(in[i1+1 : i2]),
+			string(in[i3+1 : i4]),
 		})
 	}
 
@@ -249,11 +249,12 @@ func TestUnmarshalInterface(t *testing.T) {
 		t.Error(err)
 	}
 	// Make sure that obj got the elements in the correct order (B before A).
-	if !reflect.DeepEqual(obj, []keyVal{
-		{[]byte("B"), []byte("first")},
-		{[]byte("A"), []byte("second")},
-	}) {
-		t.Errorf("Unexpected obj: %#v", obj)
+	expected := orderedMap{
+		{"B", "first"},
+		{"A", "second"},
+	}
+	if !reflect.DeepEqual(obj, expected) {
+		t.Errorf("Unexpected obj: %#v\n", obj)
 	}
 
 	buf, err := Marshal(obj)

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -1,10 +1,13 @@
 package hjson
 
-import "bytes"
+import (
+	"bytes"
+	"encoding/json"
+)
 
 type keyVal struct {
-	key   []byte
-	value []byte
+	key   string
+	value interface{}
 }
 
 type orderedMap []keyVal
@@ -18,7 +21,17 @@ func (c orderedMap) MarshalJSON() ([]byte, error) {
 		if index > 0 {
 			b.WriteString(",")
 		}
-		b.WriteString(`"` + string(elem.key) + `":"` + string(elem.value) + `"`)
+		jbuf, err := json.Marshal(elem.key)
+		if err != nil {
+			return nil, err
+		}
+		b.Write(jbuf)
+		b.WriteString(":")
+		jbuf, err = json.Marshal(elem.value)
+		if err != nil {
+			return nil, err
+		}
+		b.Write(jbuf)
 	}
 
 	b.WriteString("}")

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -1,0 +1,27 @@
+package hjson
+
+import "bytes"
+
+type keyVal struct {
+	key   []byte
+	value []byte
+}
+
+type orderedMap []keyVal
+
+func (c orderedMap) MarshalJSON() ([]byte, error) {
+	var b bytes.Buffer
+
+	b.WriteString("{")
+
+	for index, elem := range c {
+		if index > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(`"` + string(elem.key) + `":"` + string(elem.value) + `"`)
+	}
+
+	b.WriteString("}")
+
+	return b.Bytes(), nil
+}


### PR DESCRIPTION
Retain key order in objects for UnmarshalJSON() and MarshalJSON() so that implementations of ordered maps can work.

New interface ElemTyper allows custom containers implementing UnmarshalJSON() to let hjson.Unmarshal() know what type of elements they will contain, so that hjson.Unmarshal() can unmarshal numbers, booleans and null into strings if needed by the custom container.