### PR TITLE
encode: bound nesting depth to prevent stack overflow on deep input

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -314,6 +314,13 @@ func (e *hjsonEncoder) str(
 			e.parents[p] = struct{}{}
 			defer delete(e.parents, p)
 		}
+		// Bound the nesting depth so deeply-nested (non-cyclic) input cannot
+		// exhaust the stack. The cycle check above only stops repeated pointers;
+		// distinct pointers at every level slip past it. This mirrors the
+		// decoder's maxNestingDepth guard.
+		if e.pDepth > maxNestingDepth {
+			return fmt.Errorf("Exceeded max depth (%d)", maxNestingDepth)
+		}
 		defer func() { e.pDepth-- }()
 	}
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -873,5 +874,30 @@ func TestStructComment(t *testing.T) {
 }`
 	if string(h) != expected {
 		t.Errorf("Expected:\n%s\nGot:\n%s\n\n", expected, string(h))
+	}
+}
+
+func TestEncodeMaxDepth(t *testing.T) {
+	// Deeply nested, non-cyclic input must be rejected with an error rather than
+	// recursing until the goroutine stack overflows (a fatal, unrecoverable
+	// crash). The cycle check only stops repeated pointers; distinct pointers at
+	// every level slip past it, so a separate depth bound is required.
+	var deep interface{} = "leaf"
+	for i := 0; i < maxNestingDepth+100; i++ {
+		deep = []interface{}{deep}
+	}
+	if _, err := Marshal(deep); err == nil {
+		t.Error("expected an error for input nested past maxNestingDepth, got nil")
+	} else if !strings.Contains(err.Error(), "Exceeded max depth") {
+		t.Errorf("expected a max-depth error, got: %v", err)
+	}
+
+	// Modest nesting must still encode without error.
+	var shallow interface{} = "leaf"
+	for i := 0; i < 100; i++ {
+		shallow = []interface{}{shallow}
+	}
+	if _, err := Marshal(shallow); err != nil {
+		t.Errorf("modest nesting should encode without error, got: %v", err)
 	}
 }


### PR DESCRIPTION
The decoder gained a `maxNestingDepth` guard to fix a stack-exhaustion issue (GHSA-5wfc-hjrc-gq87 / GO-2026-5157), but the **encoder** was left unguarded.

The encoder’s only depth-related logic is cycle detection, which triggers solely on a *repeated* pointer:

```go
// encode.go
case reflect.Ptr, reflect.Slice, reflect.Map:
    if e.pDepth++; e.pDepth > depthLimit {
        // ... errors only if value.Pointer() was seen before (a cycle)
    }
```

A deeply nested, **non-cyclic** value has a distinct pointer at every level, so the cycle check never fires and `hjson.Marshal` recurses until the goroutine stack overflows — a fatal, unrecoverable crash (a Go stack overflow cannot be `recover()`-ed).

Reproduce (still applies to v4.6.0):

```go
var v any = "x"
for i := 0; i < 3_000_000; i++ { v = []any{v} }
_, _ = hjson.Marshal(v) // fatal error: stack overflow  (frames in encode.go)
```

**Fix:** reuse the existing `pDepth` counter to also enforce `maxNestingDepth` on the encode side, returning the same `"Exceeded max depth (%d)"` error the decoder already returns. No behavior change for normal input (nothing legitimately nests 10000 deep); the cycle check still catches true cycles early. Added a regression test (`TestEncodeMaxDepth`). `go test ./...` passes; `gofmt` clean.